### PR TITLE
Ignore lists inside of code fences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2022-19-12
+### Changed
+- No longer interferes with lists inside code fences, which would break YAML snippets.
+
 ## [1.0.1] - 2020-17-09
 ### Changed
 - Rewrote regex to handle edge cases better.

--- a/mdx_breakless_lists/mdx_breakless_lists.py
+++ b/mdx_breakless_lists/mdx_breakless_lists.py
@@ -19,9 +19,12 @@ class BreaklessListsProcessor(Preprocessor):
 
     def run(self, lines):
         previous_was_li = False
+        in_codefence = False
         new_lines = []
         for line in lines:
-            if self.LI_RE.match(line):
+            if line.startswith('```'):
+                in_codefence = not in_codefence
+            elif self.LI_RE.match(line) and not in_codefence:
                 if not previous_was_li:
                     # Add new blank line
                     new_lines.append('')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def get_readme(filename):
 
 setup(
     name='mdx_breakless_lists',
-    version='1.0.1',
+    version='1.0.2',
     author='adamb70',
     description='Python Markdown package extension to allow lists without a preceding empty line.',
     license='MIT',


### PR DESCRIPTION
Would cause issues with certain code snippets containing lists (such as YAML code), rendering extra spaces where there should be none. This is a simple check to ensure no lists inside of code fences get affected.